### PR TITLE
 some improvements to the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
+sudo: false
+
 language: php
 php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.0
 
 script: phpunit --configuration phpunit.xml --coverage-text


### PR DESCRIPTION
* disabling sudo allows to use the faster container based infrastructure
* run a build with PHP 7, but allow it to fail
* finish as fast as possible (when either a mandatory build fails or
  when only builds are left that are allowed to fail)